### PR TITLE
net-www/lynx: bump to 2.8.8 and fix cross

### DIFF
--- a/packages/net-www/lynx/lynx-2.8.8.exheres-0
+++ b/packages/net-www/lynx/lynx-2.8.8.exheres-0
@@ -24,7 +24,14 @@ DEFAULT_SRC_CONFIGURE_PARAMS=( --enable-cgi-links
                                --enable-ipv6
                                --enable-nls
                                --hates=docdir
+                               --hates=datarootdir
                                --sysconfdir='/etc/lynx'
                                --with-screen=ncursesw
                                --with-ssl='/usr' )
+
+src_install() {
+    default
+
+    edo rmdir "${IMAGE}/usr/$(exhost --target)/share"
+}
 


### PR DESCRIPTION
Note that this requires issue #1 to be resolved (pre-cross tag).